### PR TITLE
Bug#13774 - [PythonAPI] command sentio.aux.start_clean() is a duplica…

### DIFF
--- a/sentio_prober_control/Sentio/CommandGroups/AuxCleaningGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/AuxCleaningGroup.py
@@ -1,4 +1,5 @@
 from sentio_prober_control.Sentio.Response import Response
+from sentio_prober_control.Sentio.ProberBase import ProberException
 from sentio_prober_control.Sentio.CommandGroups.CommandGroupBase import CommandGroupBase
 
 
@@ -28,12 +29,20 @@ class AuxCleaningGroup(CommandGroupBase):
         self._comm.send(f"aux:cleaning:enable_auto {stat}")
         Response.check_resp(self._comm.read_line())
 
-    def start(self, touchdowns: int):
+    def start(self, touchdowns: int = None):
         """Start the cleaning procedure.
 
         Args:
             touchdowns (int): The number of touchdowns to perform.
         """
+        if touchdowns is None:
+            self._comm.send(f"aux:cleaning:start")
+        else:
+            self._comm.send(f"aux:cleaning:start {touchdowns}")
 
-        self._comm.send(f"aux:cleaning:start {touchdowns}")
-        Response.check_resp(self._comm.read_line())
+        resp = Response.check_resp(self._comm.read_line())
+        if not resp.ok():
+            raise ProberException(resp.message())
+
+        return resp.message()
+

--- a/sentio_prober_control/Sentio/CommandGroups/AuxCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/AuxCommandGroup.py
@@ -22,12 +22,4 @@ class AuxCommandGroup(ModuleCommandGroupBase):
 
         self.cleaning: AuxCleaningGroup = AuxCleaningGroup(comm)
 
-    # Ticket #13774 Remove this function. It is already present in the cleaning group!
-    @deprecated(reason="duplicated; Use the cleaning group instead.")
-    def start_clean(self):
-        self._comm.send("aux:cleaning:start")
-        resp = Response.check_resp(self._comm.read_line())
-        if not resp.ok():
-            raise ProberException(resp.message())
 
-        return resp.message()


### PR DESCRIPTION
…te of sentio.aux.cleaning.start()

1. Remove "aux:start_cleaning" in the AuxCommandGroup.
2. The touchdown parameter of "aux:cleaning:start" modified to optional.