### PR TITLE
support for encoding added; set_chuck_site_height return values changed to mimic remote command response

### DIFF
--- a/sentio_prober_control/Communication/CommunicatorBase.py
+++ b/sentio_prober_control/Communication/CommunicatorBase.py
@@ -11,7 +11,7 @@ class CommunicatorBase(ABC):
     _verbose = False
 
 
-    def connect(self, address: str) -> None:
+    def connect(self, address: str, encoding : str = 'utf-8') -> None:
         """Connect to the probe station.
 
         Must be implemented by the derived class.

--- a/sentio_prober_control/Communication/CommunicatorGpib.py
+++ b/sentio_prober_control/Communication/CommunicatorGpib.py
@@ -53,7 +53,7 @@ class CommunicatorGpib(CommunicatorBase):
         c.connect(addr)
         return c
 
-    def connect(self, address: str) -> None:
+    def connect(self, address: str, encoding : str | None = None) -> None:
         """Connects to a GPIB device at the specified address.
 
         :param addr: A string that specifies the address of the GPIB device to connect to. The address must have the format "BOARD_NAME&colon;ADDRESS"

--- a/sentio_prober_control/Communication/CommunicatorTcpIp.py
+++ b/sentio_prober_control/Communication/CommunicatorTcpIp.py
@@ -1,4 +1,5 @@
 import socket
+import locale
 
 from sentio_prober_control.Communication.CommunicatorBase import CommunicatorBase
 
@@ -12,19 +13,29 @@ class CommunicatorTcpIp(CommunicatorBase):
         self.__socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
     @staticmethod
-    def create(addr: str):
+    def create(addr: str, encoding : str | None = None) -> CommunicatorBase:
         """Create an instance of a TCP/IP communicator.
 
-        :param addr: A string that specifies the address of the TCP/IP device to connect to. The address must have the format "IP_ADDRESS&colon;PORT"
+            Args: 
+                addr (str): A string that specifies the address of the TCP/IP device to connect to. The address must have the format "IP_ADDRESS&colon;PORT"
         """
         c = CommunicatorTcpIp()
+
+        if encoding is None:
+            encoding = locale.getpreferredencoding(False)
+
         c.connect(addr)
         return c
 
-    def connect(self, address: str) -> None:
+    def connect(self, address: str, encoding : str | None = None) -> None:
         """Connect to a TCP/IP device at the specified address.
 
-            :param addr: A string that specifies the address of the TCP/IP device to connect to. The address must have the format "IP_ADDRESS&colon;PORT"
+            Args:
+                address (str): A string that specifies the address of the TCP/IP device to connect to. The address must have the format "IP_ADDRESS&colon;PORT"
+                encoding (str|None): The encoding to use for the communication. Default is None.
+
+            Returns:
+                None
         """
         tok = address.split(":")
         if len(tok) != 2:
@@ -38,27 +49,35 @@ class CommunicatorTcpIp(CommunicatorBase):
 
         self.__socket.connect((self.__address, self.__port))
 
+        if encoding is None:
+            encoding = locale.getpreferredencoding(False)
+
+        self.__reader = self.__socket.makefile(mode='r', encoding=encoding)
+
     def disconnect(self):
         """Disconnect from the TCP/IP device."""
         if CommunicatorBase._verbose:
-            print("Diconnecting comunicator to {0}".format(self.__address))
+            print(f"Diconnecting comunicator to {self.__address}")
 
         self.__socket.close()
+
 
     def send(self, msg: str):
         """Send a command to the TCP/IP device.
 
-        :param msg: The command to send.
+            Args:
+                msg (str): The command to send.
         """
 
         if CommunicatorBase._verbose:
-            print('Sending "{0}"'.format(msg))
+            print(f'Sending "{msg}"')
 
         self.__socket.send((msg + "\n").encode())
 
     def read_line(self):
         """Read a line from the TCP/IP device.
 
-        :return: The read line.
+            Returns:
+                The read line.
         """
-        return self.__socket.makefile().readline().rstrip()
+        return self.__reader.readline().rstrip()

--- a/sentio_prober_control/Communication/CommunicatorVisa.py
+++ b/sentio_prober_control/Communication/CommunicatorVisa.py
@@ -24,7 +24,7 @@ class CommunicatorVisa(CommunicatorBase):
         c.connect(addr)
         return c
 
-    def connect(self, address: str) -> None:
+    def connect(self, address: str, encoding : str | None = None) -> None:
         """Connect to a VISA device at the specified address.
 
         The VISA timeout for the interface is set to 3600000 (1 hour).
@@ -33,6 +33,7 @@ class CommunicatorVisa(CommunicatorBase):
         """
         self.__visa = self.__rm.open_resource(address)
         self.__visa.timeout = 3600000
+        self.__address = address
 
     def disconnect(self):
         """Disconnect from the VISA device."""

--- a/sentio_prober_control/Sentio/CommandGroups/LoaderVirtualCarrierCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/LoaderVirtualCarrierCommandGroup.py
@@ -1,5 +1,3 @@
-import re
-
 from typing import List, Tuple
 
 from sentio_prober_control.Sentio.CommandGroups.CommandGroupBase import CommandGroupBase


### PR DESCRIPTION
This PR will add support for explicitely setting an encoding for tcp/ip connections. Right now SENTIO should be using single byte encoding by default. But the new code will use the system default encoding if none is specified. This fixes issues in the encoding of "µ" characters on the python side and opens the door for SENTIO to switch to UTF-8 in the future.

modified ProberSentio.set_chuck_site_height to match remote command api. Return of a tuple instead of a response object. Modified the api of a couple of other remote commands that were still returning a Response object despite not having a return parameter as per the remote command specification.