### PR TITLE
Update Bug#18392

### DIFF
--- a/sentio_prober_control/Sentio/Enumerations.py
+++ b/sentio_prober_control/Sentio/Enumerations.py
@@ -2009,3 +2009,42 @@ class ZPositionHint(Enum):
             ZPositionHint.Transfer: "Transfer",
         }
         return switcher.get(self, "Invalid ZPositionHint")
+
+class SwapBridgeSide(Enum):    
+    """Control swap bridge move to right or left side.
+
+    Attributes:
+        Right (0): Move swap bridge to right side.
+        Left (1): Move swap bridge to left side.
+        Current (2): Keep bridge at current side.
+    """
+    
+    Right = 0
+    Left = 1
+    Current = 2
+    
+    def toSentioAbbr(self):
+        switcher = {
+            SwapBridgeSide.Right: "Right",
+            SwapBridgeSide.Left: "Left",
+            SwapBridgeSide.Current: "Current",
+        }
+        return switcher.get(self, "Invalid swap bridge side.")
+    
+class DevicePosition(Enum):
+    """Control swap bridge move to up or down side.
+
+    Attributes:
+        Up (0): Move device to up position.
+        Down (1): Move device to down position.
+    """
+    
+    Up = 0
+    Down = 1
+    
+    def toSentioAbbr(self):
+        switcher = {
+            DevicePosition.Up: "Up",
+            DevicePosition.Down: "Down",
+        }
+        return switcher.get(self, "Invalid device position.")

--- a/sentio_prober_control/Sentio/ProberSentio.py
+++ b/sentio_prober_control/Sentio/ProberSentio.py
@@ -25,7 +25,9 @@ from sentio_prober_control.Sentio.Enumerations import (
     VacuumState,
     HighPowerAirState,
     SoftContactState,
-    UserCoordState
+    UserCoordState,
+    SwapBridgeSide,
+    DevicePosition
 )
 
 from sentio_prober_control.Sentio.ProberBase import ProberBase, ProberException
@@ -1663,19 +1665,20 @@ class SentioProber(ProberBase):
         self.comm.send(f"start_move_indexer_pos {pos}")
         Response.check_resp(self.comm.read_line())
 
-    def swap_bridge(self, side: str, device_position: str | None = None) -> None:
-        """Control swap bridge side and position.
+    def swap_bridge(self, side: SwapBridgeSide, device_position: DevicePosition, delaytime: int = 8) -> None:
+        """Control swap bridge side,position and delay time.
 
         Args:
             side (str): right/left/current
             device_position (str, optional): up/down
-
+            delaytime (int) : 8
         Returns:
             None
         """
         cmd = f"swap_bridge {side}"
         if device_position:
             cmd += f",{device_position}"
+        cmd += f",{delaytime}"
         self.comm.send(cmd)
         Response.check_resp(self.comm.read_line())
 


### PR DESCRIPTION
The documentation of the swap bridge remote command seems incopmplete or outdated.

It lists two parameters:

Swap Bridge Side Rught/Left/Current/up/Down
Device Position: Up/Down
The device position is not a position but a direction or rather a DeviceMotionDirection.

From the implementation in SENTIO i conclude that the parameters have been merged into a single enum and a new integer parameter has been added. The documentation does not mention this.

The python API for the swap bridge should be updated too:

Use an enumerator as the parameter (or two if that is what the remote command requires)
add the integer parameter (delay time)