### PR TITLE
fix for #34 (Nanocube remote commands do not have siph prefix)

### DIFF
--- a/sentio_prober_control/Sentio/CommandGroups/ProbeCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/ProbeCommandGroup.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from sentio_prober_control.Sentio.Enumerations import ProbeSentio, XyReference, ZReference, ChuckSite
+from sentio_prober_control.Sentio.Enumerations import ProbePosition, XyReference, ZReference, ChuckSite
 from sentio_prober_control.Sentio.Response import Response
 from sentio_prober_control.Sentio.CommandGroups.CommandGroupBase import CommandGroupBase
 
@@ -16,7 +16,7 @@ class ProbeCommandGroup(CommandGroupBase):
     from sentio_prober_control.Sentio.ProberSentio import SentioProber
 
     prober = SentioProber.create_prober("tcpip", "127.0.0.1:35555")
-    prober.probe.move_probe_xy(ProbeSentio.East, XyReference.Current, 1000, 2000)
+    prober.probe.move_probe_xy(ProbePosition.East, XyReference.Current, 1000, 2000)
     ```
     """
 
@@ -24,7 +24,7 @@ class ProbeCommandGroup(CommandGroupBase):
         super().__init__(prober)
 
 
-    def async_step_probe_site(self, probe: ProbeSentio, idx: int) -> int:
+    def async_step_probe_site(self, probe: ProbePosition, idx: int) -> int:
         """Start the process of stepping to a positioner site.
 
         Each positioner can define n a number of predefined positions called "sites". This command
@@ -44,7 +44,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return resp.cmd_id()
 
 
-    def async_step_probe_site_next(self, probe: ProbeSentio) -> int:
+    def async_step_probe_site_next(self, probe: ProbePosition) -> int:
         """Step to next probe site.
 
         Each positioner can define n a number of predefined positions called "sites".
@@ -63,7 +63,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return resp.cmd_id()
 
 
-    def async_step_probe_site_first(self, probe: ProbeSentio) -> int:
+    def async_step_probe_site_first(self, probe: ProbePosition) -> int:
         """Step to first probe site.
 
         Each positioner can define n a number of predefined positions called "sites".
@@ -82,7 +82,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return resp.cmd_id()
 
 
-    def get_probe_site(self, probe: ProbeSentio, idx: int) -> Tuple[str, float, float, str]:
+    def get_probe_site(self, probe: ProbePosition, idx: int) -> Tuple[str, float, float, str]:
         """Get information for a probe site.
 
         Each positioner can define n a number of predefined positions called "sites".
@@ -101,7 +101,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return str(tok[0]), float(tok[1]), float(tok[2]), str(tok[3])
 
 
-    def get_probe_site_number(self, probe: ProbeSentio) -> int:
+    def get_probe_site_number(self, probe: ProbePosition) -> int:
         """Returns the total number of probe sites set up.
 
         Each positioner can define n a number of predefined positions called "sites".
@@ -116,7 +116,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return int(resp.message())
 
 
-    def get_probe_xy(self, probe: ProbeSentio, ref: XyReference) -> Tuple[float, float]:
+    def get_probe_xy(self, probe: ProbePosition, ref: XyReference) -> Tuple[float, float]:
         """Get probe xy position in micrometer.
 
         Args:
@@ -133,7 +133,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return float(tok[0]), float(tok[1])
 
 
-    def get_probe_z(self, probe: ProbeSentio, ref: ZReference) -> float:
+    def get_probe_z(self, probe: ProbePosition, ref: ZReference) -> float:
         """Get probe z position in micrometer.
 
         Args:
@@ -148,7 +148,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return float(resp.message())
 
 
-    def move_probe_contact(self, probe: ProbeSentio) -> float:
+    def move_probe_contact(self, probe: ProbePosition) -> float:
         """Move a probe to its contact position.
 
         Args:
@@ -163,7 +163,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return float(resp.message())
 
 
-    def move_probe_separation(self, probe: ProbeSentio) -> float:
+    def move_probe_separation(self, probe: ProbePosition) -> float:
         """Move a probe to its separation position.
 
         Args:
@@ -178,7 +178,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return float(resp.message())
 
 
-    def move_probe_home(self, probe: ProbeSentio) -> Tuple[float, float]:
+    def move_probe_home(self, probe: ProbePosition) -> Tuple[float, float]:
         """Move probe to its home position.
 
         Args:
@@ -194,7 +194,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return float(tok[0]), float(tok[1])
 
 
-    def move_probe_xy(self, probe: ProbeSentio, ref: XyReference, x: float, y: float) -> Tuple[float, float]:
+    def move_probe_xy(self, probe: ProbePosition, ref: XyReference, x: float, y: float) -> Tuple[float, float]:
         """Move probe to a given position.
 
         Args:
@@ -213,7 +213,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return float(tok[0]), float(tok[1])
 
 
-    def move_probe_z(self, probe: ProbeSentio, ref: ZReference, z: float) -> float:
+    def move_probe_z(self, probe: ProbePosition, ref: ZReference, z: float) -> float:
         """Move probe to a given z position.
 
         Args:
@@ -230,7 +230,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return float(resp.message())
 
 
-    def set_probe_contact(self, probe: ProbeSentio, z: float | None = None) -> None:
+    def set_probe_contact(self, probe: ProbePosition, z: float | None = None) -> None:
         """Set contact position of a positioner.
 
         Args:
@@ -246,7 +246,7 @@ class ProbeCommandGroup(CommandGroupBase):
         Response.check_resp(self.comm.read_line())
 
 
-    def set_probe_home(self, probe: ProbeSentio, site: ChuckSite | None = None, x: float | None = None, y: float | None = None) -> None:
+    def set_probe_home(self, probe: ProbePosition, site: ChuckSite | None = None, x: float | None = None, y: float | None = None) -> None:
         """Set home position of a probe.
 
         Args:
@@ -263,7 +263,7 @@ class ProbeCommandGroup(CommandGroupBase):
         Response.check_resp(self.comm.read_line())
 
 
-    def step_probe_site(self, probe: ProbeSentio, idx: int) -> Tuple[str, float, float]:
+    def step_probe_site(self, probe: ProbePosition, idx: int) -> Tuple[str, float, float]:
         """Step to a specific probe site.
 
         Each positioner can define n a number of predefined positions called "sites".
@@ -284,7 +284,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return tok[0], float(tok[1]), float(tok[2])
 
 
-    def step_probe_site_first(self, probe: ProbeSentio) -> Tuple[str, float, float]:
+    def step_probe_site_first(self, probe: ProbePosition) -> Tuple[str, float, float]:
         """Step to the first probe site.
 
         Each positioner can define n a number of predefined positions called "sites".
@@ -303,7 +303,7 @@ class ProbeCommandGroup(CommandGroupBase):
         return tok[0], float(tok[1]), float(tok[2])
 
 
-    def step_probe_site_next(self, probe: ProbeSentio) -> Tuple[str, float, float]:
+    def step_probe_site_next(self, probe: ProbePosition) -> Tuple[str, float, float]:
         """Step to the next probe site.
 
         Each positioner can define n a number of predefined positions called "sites".
@@ -321,7 +321,7 @@ class ProbeCommandGroup(CommandGroupBase):
         tok = resp.message().split(",")
         return tok[0], float(tok[1]), float(tok[2])
 
-    def enable_probe_motor(self, probe: ProbeSentio, status: bool) -> None:
+    def enable_probe_motor(self, probe: ProbePosition, status: bool) -> None:
         """Enable/Disable the probe motor.
 
         Probe with 3 motors will enable and disable by following behavior.
@@ -334,7 +334,7 @@ class ProbeCommandGroup(CommandGroupBase):
         self.comm.send(f"enable_positioner_motor {probe.to_string()},{status}")
         Response.check_resp(self.comm.read_line())
 
-    def get_probe_status(self, probe: ProbeSentio) -> str:
+    def get_probe_status(self, probe: ProbePosition) -> str:
         """Obtain the status of probe.
 
         Command will return 4 probe status
@@ -351,7 +351,7 @@ class ProbeCommandGroup(CommandGroupBase):
         resp = Response.check_resp(self.comm.read_line())
         return resp.message()
 
-    def set_probe_status(self, probe: ProbeSentio, status: bool) -> None:
+    def set_probe_status(self, probe: ProbePosition, status: bool) -> None:
         """Enable/Disable the probe stage in the SENTIO.
 
         Enable/Disable the Probes in the SENTIO.

--- a/sentio_prober_control/Sentio/CommandGroups/SiPHCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/SiPHCommandGroup.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
 
-from sentio_prober_control.Sentio.Enumerations import ProbeSentio, UvwAxis, FiberType
+from sentio_prober_control.Sentio.Enumerations import ProbePosition, UvwAxis, FiberType, CompatibilityLevel
 from sentio_prober_control.Sentio.Response import Response
 from sentio_prober_control.Sentio.CommandGroups.CommandGroupBase import CommandGroupBase
 
@@ -18,7 +18,6 @@ class SiPHCommandGroup(CommandGroupBase):
 
     def fast_alignment(self) -> None:
         """Perform fast fiber alignment."""
-
         self.comm.send("siph:fast_alignment")
         Response.check_resp(self.comm.read_line())
 
@@ -26,12 +25,11 @@ class SiPHCommandGroup(CommandGroupBase):
     def get_cap_sensor(self) -> Tuple[float, float]:
         """Get the capacitance sensor value.
 
-        :raises: ProberException if an error occured.
-        :return: A tuple with the values from the capacity sensors of probe 1 and probe 2.
+        Returns:
+            A tuple with the values from the capacity sensors of probe 1 and probe 2.
         """
         self.comm.send("siph:get_cap_sensor")
         resp = Response.check_resp(self.comm.read_line())
-
         tok = resp.message().split(",")
         return float(tok[0]), float(tok[1])
 
@@ -51,36 +49,41 @@ class SiPHCommandGroup(CommandGroupBase):
     def gradient_search(self) -> None:
         """Execute SiPh gradient search.
 
-        :raises: ProberException if an error occured.
+           Returns:
+                None
         """
 
         self.comm.send("siph:gradient_search")
         Response.check_resp(self.comm.read_line())
 
 
-    def move_hover(self, probe: ProbeSentio) -> None:
+    def move_hover(self, probe: ProbePosition) -> None:
         """Move SiPh probe to hover height.
 
-        :param probe: The probe on which the SiPh probe is mounted.
-        :raises: ProberException if an error occured.
+        Args:
+            probe: The probe on which the SiPh probe is mounted.
         """
 
         self.comm.send(f"siph:move_hover {probe.to_string()}")
         Response.check_resp(self.comm.read_line())
 
 
-    def move_separation(self, probe: ProbeSentio) -> None:
+    def move_separation(self, probe: ProbePosition) -> None:
         """Move SiPh probe to separation height.
 
-        :param probe: The probe on which the SiPh probe is mounted.
-        :raises: ProberException if an error occured.
+        Args:
+            probe: The probe on which the SiPh probe is mounted.
+
+        Returns:
+            None
         """
 
         self.comm.send(f"siph:move_separation {probe.to_string()}")
         Response.check_resp(self.comm.read_line())
 
-    def coupling(self, probe: ProbeSentio, axis: UvwAxis) -> None:
-        """Start execute coupling .
+
+    def coupling(self, probe: ProbePosition, axis: UvwAxis) -> None:
+        """Start execute coupling.
 
         Args:
             probe: Execute probe.
@@ -90,7 +93,8 @@ class SiPHCommandGroup(CommandGroupBase):
         self.comm.send(f"siph:coupling {probe.to_string()},{axis.to_string()}")
         Response.check_resp(self.comm.read_line())
 
-    def get_alignment(self, probe: ProbeSentio, fiber_type: FiberType) -> Tuple[bool, bool, bool, bool]:
+
+    def get_alignment(self, probe: ProbePosition, fiber_type: FiberType) -> Tuple[bool, bool, bool, bool]:
         """Get the fast alignment function enable including Coarse, Fine, Gradient, and Rotary/Focal searching.
 
         Args:
@@ -111,7 +115,8 @@ class SiPHCommandGroup(CommandGroupBase):
 
         return coarse, fine, gradient, rotary_focal
 
-    def set_origin(self, probe: ProbeSentio) -> None:
+
+    def set_origin(self, probe: ProbePosition) -> None:
         """Set the current position as the origin position for the SiPH positioner.
 
         Args:
@@ -120,10 +125,12 @@ class SiPHCommandGroup(CommandGroupBase):
         Returns:
             A Response object containing the command execution status.
         """
+
         self.comm.send(f"siph:set_origin {probe.to_string()}")
         Response.check_resp(self.comm.read_line())
 
-    def move_origin(self, probe: ProbeSentio) -> None:
+
+    def move_origin(self, probe: ProbePosition) -> None:
         """Move SiPH positioner to its origin position.
 
         The movement includes:
@@ -140,7 +147,8 @@ class SiPHCommandGroup(CommandGroupBase):
         self.comm.send(f"siph:move_origin {probe.to_string()}")
         Response.check_resp(self.comm.read_line())
 
-    def move_position_uvw(self, probe: ProbeSentio, axis: UvwAxis, degree: float) -> float:
+
+    def move_position_uvw(self, probe: ProbePosition, axis: UvwAxis, degree: float) -> float:
         """Move the SiPH positioner target axis with a relative degree.
 
         Args:
@@ -156,7 +164,8 @@ class SiPHCommandGroup(CommandGroupBase):
 
         return float(resp.message())
 
-    def pivot_point(self, probe: ProbeSentio) -> None:
+
+    def pivot_point(self, probe: ProbePosition) -> None:
         """Run pivot point calibration for the specified positioner.
 
         Args:
@@ -168,7 +177,8 @@ class SiPHCommandGroup(CommandGroupBase):
         self.comm.send(f"siph:pivot_point {probe.to_string()}")
         Response.check_resp(self.comm.read_line())
 
-    def set_alignment(self, probe: ProbeSentio, fiber_type: FiberType, coarse: bool, fine: bool, gradient: bool,
+
+    def set_alignment(self, probe: ProbePosition, fiber_type: FiberType, coarse: bool, fine: bool, gradient: bool,
                       rotary: bool) -> None:
         """Set the fast alignment function enable including Coarse, Fine, Gradient, and Rotary/Focal searching.
 
@@ -188,9 +198,9 @@ class SiPHCommandGroup(CommandGroupBase):
         gradient_str = "ON" if gradient else "OFF"
         rotary_str = "ON" if rotary else "OFF"
 
-        self.comm.send(
-            f"siph:set_alignment {probe.to_string()},{fiber_type},{coarse_str},{fine_str},{gradient_str},{rotary_str}")
+        self.comm.send(f"siph:set_alignment {probe.to_string()},{fiber_type},{coarse_str},{fine_str},{gradient_str},{rotary_str}")
         Response.check_resp(self.comm.read_line())
+
 
     def set_pivot_point(self, rotary_angle_1: float, rotary_angle_2: float, leveling_angle: float, repeats: int) -> None:
         """Set the parameters for the pivot point function.
@@ -207,6 +217,7 @@ class SiPHCommandGroup(CommandGroupBase):
         self.comm.send(f"siph:set_pivot_point {rotary_angle_1},{rotary_angle_2},{leveling_angle},{repeats}")
         Response.check_resp(self.comm.read_line())
 
+
     def download_graph_data(self, file_path: str, file_name: str) -> None:
         """Download the graph data and save it to the specified location.
 
@@ -217,8 +228,12 @@ class SiPHCommandGroup(CommandGroupBase):
         Returns:
             A Response object containing the command execution status.
         """
+        if self.prober.compatibility_level < CompatibilityLevel.Sentio_25:
+            raise NotImplementedError(f"download_graph_data is not supported in compatibility level {self.prober.compatibility_level}.")
+
         self.comm.send(f"siph:download_graph_data {file_path}, {file_name}")
         Response.check_resp(self.comm.read_line())
+
 
     def start_tracking(self, timeout: int = 60) -> int:
         """Start the SiPH positioner gradient tracking search asynchronously.
@@ -236,7 +251,8 @@ class SiPHCommandGroup(CommandGroupBase):
         command_id = int(resp.cmd_id())
         return command_id
 
-    def move_nanocube_xy(self, probe: ProbeSentio, x: float, y: float) -> tuple[float, float]:
+
+    def move_nanocube_xy(self, probe: ProbePosition, x: float, y: float) -> tuple[float, float]:
         """Move NanoCube to the target XY position.
 
         The movement range is limited to 0 ~ 100 μm.
@@ -252,7 +268,7 @@ class SiPHCommandGroup(CommandGroupBase):
         if not (0 <= x <= 100 and 0 <= y <= 100):
             raise ValueError("X and Y values must be between 0 and 100 μm.")
 
-        self.comm.send(f"siph:move_nanocube_xy {probe.to_string()},{x},{y}")
+        self.comm.send(f"move_nanocube_xy {probe.to_string()},{x},{y}")
         resp = Response.check_resp(self.comm.read_line())
 
         # Parse response message
@@ -261,7 +277,8 @@ class SiPHCommandGroup(CommandGroupBase):
         new_y = float(tok[1])
         return new_x, new_y
 
-    def get_nanocube_xy(self, probe: ProbeSentio) -> tuple[float, float]:
+
+    def get_nanocube_xy(self, probe: ProbePosition) -> tuple[float, float]:
         """Get the current NanoCube XY position.
 
         Args:
@@ -270,7 +287,7 @@ class SiPHCommandGroup(CommandGroupBase):
         Returns:
             A tuple containing the current X and Y positions.
         """
-        self.comm.send(f"siph:get_nanocube_xy {probe.to_string()}")
+        self.comm.send(f"get_nanocube_xy {probe.to_string()}")
         resp = Response.check_resp(self.comm.read_line())
 
         # Parse response message
@@ -279,7 +296,8 @@ class SiPHCommandGroup(CommandGroupBase):
         current_y = float(tok[1])
         return current_x, current_y
 
-    def get_nanocube_z(self, probe: ProbeSentio) -> float:
+
+    def get_nanocube_z(self, probe: ProbePosition) -> float:
         """Get the current NanoCube Z position.
 
         Args:
@@ -288,7 +306,7 @@ class SiPHCommandGroup(CommandGroupBase):
         Returns:
             The current Z position.
         """
-        self.comm.send(f"siph:get_nanocube_z {probe.to_string()}")
+        self.comm.send(f"get_nanocube_z {probe.to_string()}")
         resp = Response.check_resp(self.comm.read_line())
 
         # Parse response message

--- a/sentio_prober_control/Sentio/Enumerations.py
+++ b/sentio_prober_control/Sentio/Enumerations.py
@@ -376,6 +376,17 @@ class ColorScheme(Enum):
         return switcher.get(self, "Invalid ColorScheme")
 
 
+class CompatibilityLevel(Enum):
+    """ Compatibility level of the prober. 
+    
+        The compatibility level is determined at time of instantiating the prober class. 
+        It is used to determine which features are available in the prober.
+    """
+    Undefined = 0,
+    Sentio_24 = 1,
+    Sentio_25 = 2
+
+
 @deprecated(reason="duplicated; use DieCompensationMode instead.")
 class Compensation(Enum):
     Lateral = 0
@@ -1227,7 +1238,7 @@ class TestSelection(Enum):
         return switcher.get(self, "Invalid TestSelection")
 
 
-class ProbeSentio(Enum):
+class ProbePosition(Enum):
     """An enumeration containing a list of position for motorized probes.
 
     Attributes:
@@ -1235,21 +1246,33 @@ class ProbeSentio(Enum):
         West (1): Probe is on the left side of the chuck.
         North (2): Probe is at the back side of the prober.
         South (3): Probe is on the front side of the prober.
+        NorthEast (4): Probe is at the back right side of the prober.
+        SouthEast (5): Probe is at the front right side of the prober.
+        SouthWest (6): Probe is at the front left side of the prober.
+        NorthWest (7): Probe is at the back left side of the prober.
     """
 
     East = 0
     West = 1
     North = 2
     South = 3
+    NorthEast = 4,
+    SouthEast = 5,
+    SouthWest = 6,
+    NorthWest = 7
 
     def to_string(self):
         switcher = {
-            ProbeSentio.East: "East",
-            ProbeSentio.West: "West",
-            ProbeSentio.North: "North",
-            ProbeSentio.South: "South",
+            ProbePosition.East: "East",
+            ProbePosition.West: "West",
+            ProbePosition.North: "North",
+            ProbePosition.South: "South",
+            ProbePosition.NorthEast: "NorthEast",
+            ProbePosition.SouthEast: "SouthEast",
+            ProbePosition.SouthWest: "SouthWest",
+            ProbePosition.NorthWest: "NorthWest",
         }
-        return switcher.get(self, "Invalid ProbeSentio enumerator")
+        return switcher.get(self, "Invalid ProbePosition enumerator")
 
 
 class PtpaFindTipsMode(Enum):

--- a/sentio_prober_control/UnitTest/TestProbeCommandGroup.py
+++ b/sentio_prober_control/UnitTest/TestProbeCommandGroup.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
-from sentio_prober_control.Sentio.Enumerations import ProbeSentio, ProbeXYReference, ProbeZReference
+from sentio_prober_control.Sentio.Enumerations import ProbePosition, ProbeXYReference, ProbeZReference
 from sentio_prober_control.Communication.CommunicatorTcpIp import CommunicatorTcpIp
 from sentio_prober_control.Sentio.ProberSentio import SentioProber
 class TestProbeCommandGroup(unittest.TestCase):
@@ -12,38 +12,38 @@ class TestProbeCommandGroup(unittest.TestCase):
         self.test_prober = SentioProber(self.mock_comm)
     def test_async_step_probe_site(self):
         self.mock_comm.read_line.return_value = "0,123,OK"
-        cmd_id = self.test_prober.probe.async_step_probe_site(ProbeSentio.East, 1)
+        cmd_id = self.test_prober.probe.async_step_probe_site(ProbePosition.East, 1)
         self.mock_comm.send.assert_called_with("start_step_positioner_site East,1")
         self.assertEqual(cmd_id, 123)
 
     def test_get_probe_site(self):
         self.mock_comm.read_line.return_value = "0,0,site1,1000,2000,Home"
-        result = self.test_prober.probe.get_probe_site(ProbeSentio.East, 0)
+        result = self.test_prober.probe.get_probe_site(ProbePosition.East, 0)
         self.mock_comm.send.assert_called_with("get_positioner_site East,0")
         self.assertEqual(result, ("site1", 1000.0, 2000.0, "Home"))
 
     def test_get_probe_xy(self):
         self.mock_comm.read_line.return_value = "0,0,1500,2500"
-        result = self.test_prober.probe.get_probe_xy(ProbeSentio.West, ProbeXYReference.Current)
+        result = self.test_prober.probe.get_probe_xy(ProbePosition.West, ProbeXYReference.Current)
         self.mock_comm.send.assert_called_with("get_positioner_xy West,Current")
         self.assertEqual(result, (1500.0, 2500.0))
     #
     def test_get_probe_z(self):
         self.mock_comm.read_line.return_value = "0,0,500"
-        result = self.test_prober.probe.get_probe_z(ProbeSentio.North, ProbeZReference.Zero)
+        result = self.test_prober.probe.get_probe_z(ProbePosition.North, ProbeZReference.Zero)
         self.mock_comm.send.assert_called_with("get_positioner_z North,Zero")
         self.assertEqual(result, 500.0)
 
     # ---missing the relative---
     def test_move_probe_xy(self):
         self.mock_comm.read_line.return_value = "0,0,3000,4000"
-        result = self.test_prober.probe.move_probe_xy(ProbeSentio.South, ProbeXYReference.Home, 3000, 4000)
+        result = self.test_prober.probe.move_probe_xy(ProbePosition.South, ProbeXYReference.Home, 3000, 4000)
         self.mock_comm.send.assert_called_with("move_positioner_xy South,Home,3000,4000")
         self.assertEqual(result, (3000.0, 4000.0))
 
     def test_move_probe_z(self):
         self.mock_comm.read_line.return_value = "0,0,1200"
-        result = self.test_prober.probe.move_probe_z(ProbeSentio.West, ProbeZReference.Contact, 1200)
+        result = self.test_prober.probe.move_probe_z(ProbePosition.West, ProbeZReference.Contact, 1200)
         self.mock_comm.send.assert_called_with("move_positioner_z West,Contact,1200")
         self.assertEqual(result, 1200.0)
 

--- a/sentio_prober_control/UnitTest/TestSiPHCommanfGroup.py
+++ b/sentio_prober_control/UnitTest/TestSiPHCommanfGroup.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 from sentio_prober_control.Communication.CommunicatorTcpIp import CommunicatorTcpIp
-from sentio_prober_control.Sentio.Enumerations import ProbeSentio, UvwAxis, FiberType
+from sentio_prober_control.Sentio.Enumerations import ProbePosition, UvwAxis, FiberType
 from sentio_prober_control.Sentio.ProberSentio import SentioProber
 from sentio_prober_control.Sentio.Response import Response
 
@@ -43,19 +43,19 @@ class TestSiPHCommandGroup(unittest.TestCase):
     def test_move_hover(self):
         """Test move_hover method."""
         self.mock_comm.read_line.return_value = "0,0,OK"
-        self.test_prober.siph.move_hover(ProbeSentio.East)
+        self.test_prober.siph.move_hover(ProbePosition.East)
         self.mock_comm.send.assert_called_with("siph:move_hover East")
 
     def test_coupling(self):
         """Test coupling method."""
         self.mock_comm.read_line.return_value = "0,0,OK"
-        self.test_prober.siph.coupling(ProbeSentio.East, UvwAxis.V)
+        self.test_prober.siph.coupling(ProbePosition.East, UvwAxis.V)
         self.mock_comm.send.assert_called_with("siph:coupling East,V")
 
     def test_get_alignment(self):
         """Test get_alignment method."""
         self.mock_comm.read_line.return_value = "0,0,true,false,true,true"
-        coarse, fine, gradient, rotary = self.test_prober.siph.get_alignment(ProbeSentio.West, FiberType.Single)
+        coarse, fine, gradient, rotary = self.test_prober.siph.get_alignment(ProbePosition.West, FiberType.Single)
         self.mock_comm.send.assert_called_with("siph:get_alignment West,Single")
         self.assertTrue(coarse)
         self.assertFalse(fine)
@@ -65,32 +65,32 @@ class TestSiPHCommandGroup(unittest.TestCase):
     def test_set_origin(self):
         """Test set_origin method."""
         self.mock_comm.read_line.return_value = "0,0,OK"
-        self.test_prober.siph.set_origin(ProbeSentio.East)
+        self.test_prober.siph.set_origin(ProbePosition.East)
         self.mock_comm.send.assert_called_with("siph:set_origin East")
 
     def test_move_origin(self):
         """Test move_origin method."""
         self.mock_comm.read_line.return_value = "0,0,OK"
-        self.test_prober.siph.move_origin(ProbeSentio.West)
+        self.test_prober.siph.move_origin(ProbePosition.West)
         self.mock_comm.send.assert_called_with("siph:move_origin West")
 
     def test_move_position_uvw(self):
         """Test move_position_uvw method."""
         self.mock_comm.read_line.return_value = "0,0,0.2"
-        position = self.test_prober.siph.move_position_uvw(ProbeSentio.East, UvwAxis.U, 0.1)
+        position = self.test_prober.siph.move_position_uvw(ProbePosition.East, UvwAxis.U, 0.1)
         self.mock_comm.send.assert_called_with("siph:move_position_uvw East,U,0.1")
         self.assertEqual(position, 0.2)
 
     def test_pivot_point(self):
         """Test pivot_point method."""
         self.mock_comm.read_line.return_value = "0,0,OK"
-        self.test_prober.siph.pivot_point(ProbeSentio.West)
+        self.test_prober.siph.pivot_point(ProbePosition.West)
         self.mock_comm.send.assert_called_with("siph:pivot_point West")
 
     def test_move_nanocube_xy(self):
         """Test move_nanocube_xy method."""
         self.mock_comm.read_line.return_value = "0,0,50.000,50.000"
-        x, y = self.test_prober.siph.move_nanocube_xy(ProbeSentio.East, 50, 50)
+        x, y = self.test_prober.siph.move_nanocube_xy(ProbePosition.East, 50, 50)
         self.mock_comm.send.assert_called_with("siph:move_nanocube_xy East,50,50")
         self.assertEqual(x, 50.000)
         self.assertEqual(y, 50.000)
@@ -98,7 +98,7 @@ class TestSiPHCommandGroup(unittest.TestCase):
     def test_get_nanocube_xy(self):
         """Test get_nanocube_xy method."""
         self.mock_comm.read_line.return_value = "0,0,50.000,50.000"
-        x, y = self.test_prober.siph.get_nanocube_xy(ProbeSentio.East)
+        x, y = self.test_prober.siph.get_nanocube_xy(ProbePosition.East)
         self.mock_comm.send.assert_called_with("siph:get_nanocube_xy East")
         self.assertEqual(x, 50.000)
         self.assertEqual(y, 50.000)
@@ -106,7 +106,7 @@ class TestSiPHCommandGroup(unittest.TestCase):
     def test_get_nanocube_z(self):
         """Test get_nanocube_z method."""
         self.mock_comm.read_line.return_value = "0,0,50.000"
-        z = self.test_prober.siph.get_nanocube_z(ProbeSentio.West)
+        z = self.test_prober.siph.get_nanocube_z(ProbePosition.West)
         self.mock_comm.send.assert_called_with("siph:get_nanocube_z West")
         self.assertEqual(z, 50.000)
 


### PR DESCRIPTION
- removed siph prefix from nanocube remote commands
- added a property for the prober class to find out the sentio compatibility level 
- renamed ProbeSentio enum to ProbePosition
- Added enumerations for mixed cardinal directions to ProbePosition enum