### PR TITLE
Fix for #38 (ZReference Bug when communicating with SENTIO 24.x)

### DIFF
--- a/sentio_prober_control/Sentio/CommandGroups/ProbeCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/ProbeCommandGroup.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from sentio_prober_control.Sentio.Enumerations import ProbePosition, XyReference, ZReference, ChuckSite
 from sentio_prober_control.Sentio.Response import Response
 from sentio_prober_control.Sentio.CommandGroups.CommandGroupBase import CommandGroupBase
-
+from sentio_prober_control.Sentio.Compatibility import Compatibility, CompatibilityLevel
 
 class ProbeCommandGroup(CommandGroupBase):
     """This command group contains functions for working with motorized prober.
@@ -143,7 +143,12 @@ class ProbeCommandGroup(CommandGroupBase):
         Returns:
             The z position in micrometer.
         """
-        self.comm.send(f"get_positioner_z {probe.to_string()},{ref.to_string()}")
+        
+        # Note: 
+        # Even in Sentio 24.x the ref parameter is expected in long form! This is why we use 
+        # CompatibilityLevel.Sentio_25_2 here.
+        self.comm.send(f"get_positioner_z {probe.to_string()},{ref.to_string(CompatibilityLevel.Sentio_25_2)}")
+
         resp = Response.check_resp(self.comm.read_line())
         return float(resp.message())
 
@@ -225,7 +230,10 @@ class ProbeCommandGroup(CommandGroupBase):
             The z position after the move in micrometer (from zero).
         """
 
-        self.comm.send(f"move_positioner_z {probe.to_string()},{ref.to_string()},{z}")
+        # Note:
+        # Even in Sentio 24.x the ref parameter is expected in long form! This is why we use
+        # CompatibilityLevel.Sentio_25_2 here.
+        self.comm.send(f"move_positioner_z {probe.to_string()},{ref.to_string(CompatibilityLevel.Sentio_25_2)},{z}")
         resp = Response.check_resp(self.comm.read_line())
         return float(resp.message())
 

--- a/sentio_prober_control/Sentio/CommandGroups/SiPHCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/SiPHCommandGroup.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-
+from sentio_prober_control.Sentio.Compatibility import Compatibility, CompatibilityLevel
 from sentio_prober_control.Sentio.Enumerations import ProbePosition, UvwAxis, FiberType, CompatibilityLevel
 from sentio_prober_control.Sentio.Response import Response
 from sentio_prober_control.Sentio.CommandGroups.CommandGroupBase import CommandGroupBase
@@ -228,8 +228,7 @@ class SiPHCommandGroup(CommandGroupBase):
         Returns:
             A Response object containing the command execution status.
         """
-        if self.prober.compatibility_level < CompatibilityLevel.Sentio_25:
-            raise NotImplementedError(f"download_graph_data is not supported in compatibility level {self.prober.compatibility_level}.")
+        Compatibility.assert_min(CompatibilityLevel.Sentio_25_2)
 
         self.comm.send(f"siph:download_graph_data {file_path}, {file_name}")
         Response.check_resp(self.comm.read_line())

--- a/sentio_prober_control/Sentio/Compatibility.py
+++ b/sentio_prober_control/Sentio/Compatibility.py
@@ -1,0 +1,38 @@
+from enum import IntEnum
+
+
+class CompatibilityLevel(IntEnum):
+    """ Compatibility level of the prober. 
+    
+        The compatibility level is determined at time of instantiating the prober class. 
+        It is used to determine which features are available in the prober. This enum
+        only contains SENTIO versions which introduces API changes.
+    """
+    Undefined = 0,
+    Sentio_24 = 1,
+    Sentio_25_2 = 2
+
+
+class Compatibility:
+    """Compatibility class to determine the compatibility level of the prober.
+    
+    The compatibility level is determined at time of instantiating the prober class.
+    It is used to determine which features are available in the prober. This class
+    only contains SENTIO versions which introduces API changes.
+    """
+    
+    # Default compatibility level is Undefined 
+    level : CompatibilityLevel = CompatibilityLevel.Undefined
+
+    @staticmethod
+    def assert_min(level : CompatibilityLevel) -> None:
+        """Asserts that the compatibility level is at least the given level.
+        
+        Args:
+            level (CompatibilityLevel): The minimum compatibility level required.
+        
+        Raises:
+            RuntimeError: If the current compatibility level is lower than the required level.
+        """
+        if Compatibility.level < level:
+            raise RuntimeError(f"Compatibility level {Compatibility.level} is lower than required {level}.")

--- a/sentio_prober_control/Sentio/Enumerations.py
+++ b/sentio_prober_control/Sentio/Enumerations.py
@@ -2,6 +2,9 @@ from enum import Enum
 
 from deprecated import deprecated
 
+from sentio_prober_control.Sentio.Compatibility import CompatibilityLevel, Compatibility
+
+
 class AccessLevel(Enum):
     """Specifies a SENTIO access level.
 
@@ -374,17 +377,6 @@ class ColorScheme(Enum):
     def to_string(self):
         switcher = {ColorScheme.ColorFromBin: 0, ColorScheme.ColorFromValue: 1}
         return switcher.get(self, "Invalid ColorScheme")
-
-
-class CompatibilityLevel(Enum):
-    """ Compatibility level of the prober. 
-    
-        The compatibility level is determined at time of instantiating the prober class. 
-        It is used to determine which features are available in the prober.
-    """
-    Undefined = 0,
-    Sentio_24 = 1,
-    Sentio_25 = 2
 
 
 @deprecated(reason="duplicated; use DieCompensationMode instead.")
@@ -2056,18 +2048,43 @@ class ZReference(Enum):
     Ready = 7
     RealPos = 8
 
-    def to_string(self):
-        switcher = {
-            ZReference.Contact: "C",
-            ZReference.Separation: "S",
-            ZReference.Hover: "H",
-            ZReference.Zero: "Z",
-            ZReference.Current: "R",
-            ZReference.Vce1: "VCE01",
-            ZReference.Vce2: "VCE02",
-            ZReference.Ready: "Ready",
-            ZReference.RealPos: "RealPos",
-        }
+    def to_string(self, compat_level : CompatibilityLevel = CompatibilityLevel.Undefined) -> str:
+        if compat_level == CompatibilityLevel.Undefined:
+            compat_level = Compatibility.level
+
+        if compat_level < CompatibilityLevel.Sentio_25_2:
+            # This is the original implementation for SENTIO <25.2. 
+            # Older versions of SENTIO are inconsistent with what they expect 
+            # as remote command parameters. Most older remote commands accept both 
+            # long and short form of the z reference although some may only work with 
+            # the long form.
+            switcher = {
+                ZReference.Contact: "C",
+                ZReference.Separation: "S",
+                ZReference.Hover: "H",
+                ZReference.Zero: "Z",
+                ZReference.Current: "R",
+                ZReference.Vce1: "VCE01",
+                ZReference.Vce2: "VCE02",
+                ZReference.Ready: "Ready",
+                ZReference.RealPos: "RealPos",
+            }
+        else:
+            # This is for SENTIO >=25.2.
+            # Newer versions of SENTIO always accept both long and short versions. 
+            # For clarity the long version is used exclusively.
+            switcher = {
+                ZReference.Contact: "Contact",
+                ZReference.Separation: "Separation",
+                ZReference.Hover: "Hover",
+                ZReference.Zero: "Zero",
+                ZReference.Current: "Current",
+                ZReference.Vce1: "VCE01",
+                ZReference.Vce2: "VCE02",
+                ZReference.Ready: "Ready",
+                ZReference.RealPos: "RealPos",
+            }
+
         return switcher.get(self, "Invalid chuck z reference")
     
     @staticmethod


### PR DESCRIPTION
- Added a class to manage the SENTIO compatibility layer
- modified "get_positioner_z" and "move_positioner_z" to send compatible parameters when talking to SENTIO 24.x