### PR TITLE
Added support for generic stage commands for probes

### DIFF
--- a/sentio_prober_control/Sentio/CommandGroups/ScopeCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/ScopeCommandGroup.py
@@ -1,0 +1,34 @@
+
+from typing import Optional
+
+
+from sentio_prober_control.Sentio.CommandGroups.StageCommandGroup import StageCommandGroup
+from sentio_prober_control.Sentio.Compatibility import CompatibilityLevel, Compatibility
+from sentio_prober_control.Sentio.Enumerations import Stage
+
+
+
+
+
+class ScopeCommandGroup(StageCommandGroup):
+    """This command group contains functions for working with motorized scopes.
+    You are not meant to instantiate this class directly. Access it via the probe attribute
+    of the [SentioProber](SentioProber.md) class.
+
+    Example:
+
+    ```py
+    from sentio_prober_control.Sentio.ProberSentio import SentioProber
+
+    prober = SentioProber.create_prober("tcpip", "127.0.0.1:35555")
+    prober.scope.move_probe_xy(XyReference.Current, 1000, 2000)
+    ```
+    """
+
+    def __init__(self, prober: 'SentioProber', stage : Stage, stage_selector : str) -> None: # type: ignore
+        super().__init__(prober, stage, stage_selector)
+
+        if Compatibility.level >= CompatibilityLevel.Sentio_25_2:
+            self.top : StageCommandGroup = StageCommandGroup(self, Stage.Scope, "scope:top")
+            self.bottom : StageCommandGroup = StageCommandGroup(self, Stage.BottomScope, "scope:bottom")
+            self.aux : StageCommandGroup = StageCommandGroup(self, Stage.AuxiliaryScope, "scope:aux")

--- a/sentio_prober_control/Sentio/CommandGroups/StageCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/StageCommandGroup.py
@@ -6,8 +6,9 @@ from sentio_prober_control.Sentio.CommandGroups.CommandGroupBase import CommandG
 
 from typing import Optional
 
+
 class StageCommandGroup(CommandGroupBase):
-    """This command group contains functions for working with motorized scopes.
+    """This command group contains functions for working with motorized stages.
     You are not meant to instantiate this class directly. Access it via the probe attribute
     of the [SentioProber](SentioProber.md) class.
 
@@ -21,27 +22,11 @@ class StageCommandGroup(CommandGroupBase):
     ```
     """
 
-    def __init__(self, prober: 'SentioProber', stage : Stage, has_subgroups = False) -> None: # type: ignore
+    def __init__(self, prober: 'SentioProber', stage : Stage, stage_selector : str) -> None: # type: ignore
         super().__init__(prober)
 
-        self.__stage_selector: str = ""
         self.__stage = stage
-
-        if stage==Stage.Scope:
-            self.__stage_selector = "scope:top"
-        elif stage==Stage.BottomScope:
-            self.__stage_selector = "scope:bottom"
-        elif stage==Stage.AuxiliaryScope:
-            self.__stage_selector = "scope:aux"
-        elif stage==Stage.Chuck:
-            self.__stage_selector = "chuck"
-        else:
-            raise ValueError(f"Invalid stage {stage} for ScopeCommandGroup")
-
-        if stage==Stage.Scope and has_subgroups:
-            self.top: StageCommandGroup = StageCommandGroup(prober, Stage.Scope, False)
-            self.bottom: StageCommandGroup = StageCommandGroup(prober, Stage.BottomScope, False)
-            self.aux: StageCommandGroup = StageCommandGroup(prober, Stage.AuxiliaryScope, False)
+        self.__stage_selector = stage_selector
 
 
     def get_home(self, chuck_site : ChuckSite = ChuckSite.Wafer) -> Tuple[float, float, ChuckSite]:
@@ -258,3 +243,7 @@ class StageCommandGroup(CommandGroupBase):
     def stage(self) -> Stage:
         """The stage this command group is for."""
         return self.__stage
+    
+
+
+

--- a/sentio_prober_control/Sentio/Compatibility.py
+++ b/sentio_prober_control/Sentio/Compatibility.py
@@ -8,9 +8,10 @@ class CompatibilityLevel(IntEnum):
         It is used to determine which features are available in the prober. This enum
         only contains SENTIO versions which introduces API changes.
     """
-    Undefined = 0,
-    Sentio_24 = 1,
+    Auto = 0
+    Sentio_24 = 1
     Sentio_25_2 = 2
+    Experimental = 99
 
 
 class Compatibility:
@@ -22,7 +23,7 @@ class Compatibility:
     """
     
     # Default compatibility level is Undefined 
-    level : CompatibilityLevel = CompatibilityLevel.Undefined
+    level : CompatibilityLevel = CompatibilityLevel.Auto
 
     @staticmethod
     def assert_min(level : CompatibilityLevel) -> None:

--- a/sentio_prober_control/Sentio/Enumerations.py
+++ b/sentio_prober_control/Sentio/Enumerations.py
@@ -2048,8 +2048,8 @@ class ZReference(Enum):
     Ready = 7
     RealPos = 8
 
-    def to_string(self, compat_level : CompatibilityLevel = CompatibilityLevel.Undefined) -> str:
-        if compat_level == CompatibilityLevel.Undefined:
+    def to_string(self, compat_level : CompatibilityLevel = CompatibilityLevel.Auto) -> str:
+        if compat_level == CompatibilityLevel.Auto:
             compat_level = Compatibility.level
 
         if compat_level < CompatibilityLevel.Sentio_25_2:


### PR DESCRIPTION
This PR will make the generic stage commands available for probes. Syntax very similar to tremote commands.

For instance:
**x,y = prober.probe.top.east.get_home()**