### PR TITLE
Added compatibility checks for proper error reproting of #42

### DIFF
--- a/sentio_prober_control/Sentio/CommandGroups/ProbeCommandGroup.py
+++ b/sentio_prober_control/Sentio/CommandGroups/ProbeCommandGroup.py
@@ -124,6 +124,11 @@ class ProbeCommandGroup(CommandGroupBase):
         Returns:
             A tuple containing the site index, position x, the position y in micrometer and the reference.
         """
+        
+        # This command was briefly removed and is not part of the SENTIO 24.0
+        # release. It was reintroduced in 25.1.
+        Compatibility.assert_min(CompatibilityLevel.Sentio_25_1)
+
         self.comm.send(f"get_positioner_site {probe.to_string()},{idx}")
         resp = Response.check_resp(self.comm.read_line())
         tok = resp.message().split(",")

--- a/sentio_prober_control/Sentio/Compatibility.py
+++ b/sentio_prober_control/Sentio/Compatibility.py
@@ -8,9 +8,13 @@ class CompatibilityLevel(IntEnum):
         It is used to determine which features are available in the prober. This enum
         only contains SENTIO versions which introduces API changes.
     """
+    # Undefined compatibility level, used for prober instances that are not yet initialized.
+    # Do NOT use this value in your code production code. It is signalling an uninitialized 
+    # state.
     Auto = 0
-    Sentio_24 = 1
-    Sentio_25_2 = 2
+    Sentio_24_0 = 1
+    Sentio_25_1 = 2
+    Sentio_25_2 = 3
     Experimental = 99
 
 
@@ -36,4 +40,4 @@ class Compatibility:
             RuntimeError: If the current compatibility level is lower than the required level.
         """
         if Compatibility.level < level:
-            raise RuntimeError(f"Compatibility level {Compatibility.level} is lower than required {level}.")
+            raise RuntimeError(f"This command is not supported by your machine! The machine reports a compatibility level of {Compatibility.level.name} but {level.name} is required to execute the command.")


### PR DESCRIPTION
added compatibility level for version 25.1 and locked ProbeCommandGroup.py/get_probe_site against use with SENTIO 24.0

This was added to get a better error message when using the python api in question with a SENTIO version which does not support the underlying commands.