### PR TITLE
Support for list project files

### DIFF
--- a/sentio_prober_control/Sentio/Compatibility.py
+++ b/sentio_prober_control/Sentio/Compatibility.py
@@ -15,6 +15,7 @@ class CompatibilityLevel(IntEnum):
     Sentio_24_0 = 1
     Sentio_25_1 = 2
     Sentio_25_2 = 3
+    Sentio_26_2 = 4
     Experimental = 99
 
 

--- a/sentio_prober_control/Sentio/ProberSentio.py
+++ b/sentio_prober_control/Sentio/ProberSentio.py
@@ -931,6 +931,21 @@ class SentioProber(ProberBase):
         self.comm.send(f"open_project {project}, {restore_heights}")
         Response.check_resp(self.comm.read_line())
 
+
+    def list_project_files(self) -> [str]:
+        """List all project files in SENTIO's default project folder.
+
+        Wraps SENTIO's "list_project_files" remote command.
+        """
+        self.comm.send("list_project_files")
+        resp = Response.check_resp(self.comm.read_line())
+
+        import csv
+        import io
+        reader = csv.reader(io.StringIO(resp.message()))
+        return next(reader)
+
+
     def query_command_status(self, cmd_id: int) -> Response:
         """Query the status of an async command.
 

--- a/sentio_prober_control/Sentio/ProberSentio.py
+++ b/sentio_prober_control/Sentio/ProberSentio.py
@@ -115,18 +115,22 @@ class SentioProber(ProberBase):
             if match:
                 version = match.group(1)
                 parts = version.split(".")
-                major = int(parts[0]) if len(parts) > 0 else None
-                minor = int(parts[1]) if len(parts) > 1 else None
-                release = int(parts[2]) if len(parts) > 2 else None
-                if major==25 and (minor==1 or (minor==0 and release==99)):
+                major = int(parts[0]) if len(parts) > 0 else 24
+                minor = int(parts[1]) if len(parts) > 1 else 0
+                release = int(parts[2]) if len(parts) > 2 else 0
+
+                v = (major, minor, release)
+                Compatibility.level = CompatibilityLevel.Sentio_24_0
+
+                if v >= (25, 0, 99):
                     Compatibility.level = CompatibilityLevel.Sentio_25_1
-                elif major==25 and (minor==2 or (minor==1 and release==99)):
+
+                if v >= (25, 1, 99):
                     Compatibility.level = CompatibilityLevel.Sentio_25_2
-                elif major==26:
-                    # We do not have a compat level for 26 yet, but we know that it has to be at least 25.2, so we set it to 25.2 for now.
-                    Compatibility.level = CompatibilityLevel.Sentio_25_2
-                else:
-                    Compatibility.level = CompatibilityLevel.Sentio_24_0
+
+                if v >= (26, 1, 99):
+                    Compatibility.level = CompatibilityLevel.Sentio_26_2
+
 
         # make sure there is a valid compatibility level now
         assert Compatibility.level != CompatibilityLevel.Auto, "Compatibility level could not be determined. Please set it manually."
@@ -937,6 +941,8 @@ class SentioProber(ProberBase):
 
         Wraps SENTIO's "list_project_files" remote command.
         """
+
+        Compatibility.assert_min(CompatibilityLevel.Sentio_26_2)
         self.comm.send("list_project_files")
         resp = Response.check_resp(self.comm.read_line())
 


### PR DESCRIPTION
This PR adds a new compatibility level for Sentio 26.2;
It also adds a function named list_project_files to query a list of all projects located in the project folder.

I also modified the logic for determining the compatibility level; The old logic was flawed. 